### PR TITLE
Added unchecked exceptions for various error codes from the Maskinporten endpoint

### DIFF
--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
@@ -162,7 +162,7 @@ public class Maskinportenklient {
         }
         final String errorFromMaskinporten = toString(con.getErrorStream());
         final String exceptionMessage = String.format("Http response code: %s, url: '%s', scopes: '%s', message: '%s'", con.getResponseCode(),
-                tokenEndpointUrlString, accessTokenRequest, toString(con.getErrorStream()));
+                tokenEndpointUrlString, accessTokenRequest, errorFromMaskinporten);
         if(responseCode >= 400 && responseCode < 500) {
             throw new MaskinportenClientTokenRequestException(exceptionMessage, responseCode, errorFromMaskinporten);
         } else {

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
@@ -15,6 +15,8 @@ import net.jodah.expiringmap.ExpiringEntryLoader;
 import net.jodah.expiringmap.ExpiringMap;
 import net.jodah.expiringmap.ExpiringValue;
 import net.minidev.json.JSONObject;
+import no.ks.fiks.maskinporten.error.MaskinportenClientTokenRequestException;
+import no.ks.fiks.maskinporten.error.MaskinportenTokenRequestException;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -158,9 +160,14 @@ public class Maskinportenklient {
         if (responseCode == 200) {
             return toString(con.getInputStream());
         }
-
-        throw new RuntimeException(String.format("Http response code: %s, url: '%s', scopes: '%s', message: '%s'", con.getResponseCode(),
-                                                 tokenEndpointUrlString, accessTokenRequest, toString(con.getErrorStream())));
+        final String errorFromMaskinporten = toString(con.getErrorStream());
+        final String exceptionMessage = String.format("Http response code: %s, url: '%s', scopes: '%s', message: '%s'", con.getResponseCode(),
+                tokenEndpointUrlString, accessTokenRequest, toString(con.getErrorStream()));
+        if(responseCode >= 400 && responseCode < 500) {
+            throw new MaskinportenClientTokenRequestException(exceptionMessage, responseCode, errorFromMaskinporten);
+        } else {
+            throw new MaskinportenTokenRequestException(exceptionMessage, responseCode, errorFromMaskinporten);
+        }
     }
 
     private String toString(InputStream inputStream) throws IOException {

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/error/MaskinportenClientTokenRequestException.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/error/MaskinportenClientTokenRequestException.java
@@ -1,0 +1,11 @@
+package no.ks.fiks.maskinporten.error;
+
+/**
+ * Used for client errors i.e when the response status for a token request is in the 4xx range
+ */
+public class MaskinportenClientTokenRequestException extends MaskinportenTokenRequestException {
+
+    public MaskinportenClientTokenRequestException(String message, int statusCode, String maskinportenError) {
+        super(message, statusCode, maskinportenError);
+    }
+}

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/error/MaskinportenTokenRequestException.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/error/MaskinportenTokenRequestException.java
@@ -1,0 +1,24 @@
+package no.ks.fiks.maskinporten.error;
+
+/**
+ * Generic exception for all non-sucessful Maskinporten token requests
+ */
+public class MaskinportenTokenRequestException extends RuntimeException {
+
+    private final int statusCode;
+    private final String maskinportenError;
+
+    public MaskinportenTokenRequestException(String message, int statusCode, String maskinportenError) {
+        super(message);
+        this.statusCode = statusCode;
+        this.maskinportenError = maskinportenError;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMaskinportenError() {
+        return maskinportenError;
+    }
+}


### PR DESCRIPTION
I en del tilfeller får vi 403 og andre statuskoder fra Maskinporten ved generering av token. Får å gjøre det mulig for klienter å gi bedre tilbakemeldinger om ulike typer feil (f.eks ved delegering) uten å ødelegge kontrakten (ved å extende RuntimeException) lager vi noen nye unchecked exception typer som inneholder den gamle exception meldingen, statuskoden fra Digdir og body på responsen fra Maskinportens token endepunkt