### PR TITLE
Endringer i klient-API

### DIFF
--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
@@ -11,10 +11,21 @@ import java.util.Set;
 @Builder
 public class AccessTokenRequest {
 
+    /**
+     * Ønskede scopes for access token. Required.
+     */
     @Singular
     @NonNull
     Set<String> scopes;
 
+    /**
+     * Organisasjonsnummer for organisasjon som token skal hentes på vegne av. Optional.
+     */
     String consumerOrg;
+
+
+    /**
+     * Ønsket audience for access token. Optional.
+     */
     String audience;
 }

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
@@ -1,0 +1,20 @@
+package no.ks.fiks.maskinporten;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.Set;
+
+@Value
+@Builder
+public class AccessTokenRequest {
+
+    @Singular
+    @NonNull
+    Set<String> scopes;
+
+    String consumerOrg;
+    String audience;
+}

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/AccessTokenRequest.java
@@ -20,6 +20,8 @@ public class AccessTokenRequest {
 
     /**
      * Organisasjonsnummer for organisasjon som token skal hentes på vegne av. Optional.
+     *
+     * Bruk av dette krever at organisasjonen har delegert tilgangen i Altinn. Mer informasjon finnes på https://docs.digdir.no/maskinporten_func_delegering.html.
      */
     String consumerOrg;
 

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
@@ -117,6 +117,7 @@ public class Maskinportenklient {
 
     /**
      * Henter access token med spesifiserte scopes på vegne av en annen organisasjon fra Maskinporten.
+     * Bruk av dette krever at organisasjonen har delegert tilgangen i Altinn. Mer informasjon finnes på https://docs.digdir.no/maskinporten_func_delegering.html.
      *
      * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
      *
@@ -131,6 +132,7 @@ public class Maskinportenklient {
 
     /**
      * Henter access token med spesifiserte scopes på vegne av en annen organisasjon fra Maskinporten.
+     * Bruk av dette krever at organisasjonen har delegert tilgangen i Altinn. Mer informasjon finnes på https://docs.digdir.no/maskinporten_func_delegering.html.
      *
      * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
      *

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
@@ -91,29 +91,8 @@ public class Maskinportenklient {
         return Long.parseLong(value.toString());
     }
 
-    public String getAccessToken(@NonNull Collection<String> scopes) {
-        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).build());
-    }
-
-    public String getAccessToken(String... scopes) {
-        return getAccessToken(scopesToCollection(scopes));
-    }
-
-    public String getDelegatedAccessToken(@NonNull String consumerOrg, @NonNull Collection<String> scopes) {
-
-        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).consumerOrg(consumerOrg).build());
-    }
-
-    public String getDelegatedAccessToken(@NonNull String consumerOrg, String... scopes) {
-        return getDelegatedAccessToken(consumerOrg, scopesToCollection(scopes));
-    }
-
-    public String getAccessTokenWithAudience(@NonNull String audience, @NonNull Collection<String> scopes) {
-        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).audience(audience).build());
-    }
-
-    public String getAccessTokenWithAudience(@NonNull String audience, String... scopes) {
-        return getAccessTokenWithAudience(audience, scopesToCollection(scopes));
+    public String getAccessToken(AccessTokenRequest request) {
+        return getTokenForRequest(request);
     }
 
     private String getTokenForRequest(@NonNull AccessTokenRequest accessTokenRequest) {
@@ -130,7 +109,7 @@ public class Maskinportenklient {
         final String audience = properties.getAudience();
         final String issuer = properties.getIssuer();
         final String claimScopes = String.join(" ", accessTokenRequest.getScopes());
-        final String consumerOrg = Optional.ofNullable(accessTokenRequest.consumerOrg).orElse(properties.getConsumerOrg());
+        final String consumerOrg = Optional.ofNullable(accessTokenRequest.getConsumerOrg()).orElse(properties.getConsumerOrg());
         log.debug("Signing JWTRequest with audience='{}',issuer='{}',scopes='{}',consumerOrg='{}', jtiId='{}'", audience, issuer, claimScopes, consumerOrg, jtiId);
         final JWTClaimsSet.Builder claimBuilder = new JWTClaimsSet.Builder()
                 .audience(audience)
@@ -140,7 +119,7 @@ public class Maskinportenklient {
                 .issueTime(new Date(issuedTimeInMillis))
                 .expirationTime(new Date(expirationTimeInMillis));
         Optional.ofNullable(consumerOrg).ifPresent(it -> claimBuilder.claim(CLAIM_CONSUMER_ORG, it));
-        Optional.ofNullable(accessTokenRequest.audience).ifPresent(it -> claimBuilder.claim(CLAIM_RESOURCE, it));
+        Optional.ofNullable(accessTokenRequest.getAudience()).ifPresent(it -> claimBuilder.claim(CLAIM_RESOURCE, it));
 
         final SignedJWT signedJWT = new SignedJWT(jwsHeader, claimBuilder
                 .build());
@@ -246,13 +225,5 @@ public class Maskinportenklient {
 
     private static Collection<String> scopesToCollection(String... scopes) {
         return Arrays.asList(String.join(" ", scopes).split("\\s"));
-    }
-
-    @Value
-    @Builder
-    private static class AccessTokenRequest {
-        @NonNull Set<String> scopes;
-        String consumerOrg;
-        String audience;
     }
 }

--- a/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
+++ b/maskinporten-client/src/main/java/no/ks/fiks/maskinporten/Maskinportenklient.java
@@ -6,9 +6,7 @@ import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jose.util.JSONObjectUtils;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import lombok.Builder;
 import lombok.NonNull;
-import lombok.Value;
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringEntryLoader;
 import net.jodah.expiringmap.ExpiringMap;
@@ -91,7 +89,94 @@ public class Maskinportenklient {
         return Long.parseLong(value.toString());
     }
 
-    public String getAccessToken(AccessTokenRequest request) {
+    /**
+     * Henter access token med spesifiserte scopes fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getAccessToken(@NonNull Collection<String> scopes) {
+        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).build());
+    }
+
+    /**
+     * Henter access token med spesifiserte scopes fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getAccessToken(String... scopes) {
+        return getAccessToken(scopesToCollection(scopes));
+    }
+
+    /**
+     * Henter access token med spesifiserte scopes på vegne av en annen organisasjon fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param consumerOrg Organisasjonsnummer for organisasjon token skal hentes på vegne av
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getDelegatedAccessToken(@NonNull String consumerOrg, @NonNull Collection<String> scopes) {
+        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).consumerOrg(consumerOrg).build());
+    }
+
+    /**
+     * Henter access token med spesifiserte scopes på vegne av en annen organisasjon fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param consumerOrg Organisasjonsnummer for organisasjon token skal hentes på vegne av
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getDelegatedAccessToken(@NonNull String consumerOrg, String... scopes) {
+        return getDelegatedAccessToken(consumerOrg, scopesToCollection(scopes));
+    }
+
+    /**
+     * Henter access token med spesifiserte scopes og audience fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param audience Ønsket audience for access token
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getAccessTokenWithAudience(@NonNull String audience, @NonNull Collection<String> scopes) {
+        return getTokenForRequest(AccessTokenRequest.builder().scopes(new HashSet<>(scopes)).audience(audience).build());
+    }
+
+    /**
+     * Henter access token med spesifiserte scopes og audience fra Maskinporten.
+     *
+     * @deprecated Bruk {@link #getAccessToken(AccessTokenRequest)}
+     *
+     * @param audience Ønsket audience for access token
+     * @param scopes Forespurte scopes for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    @Deprecated
+    public String getAccessTokenWithAudience(@NonNull String audience, String... scopes) {
+        return getAccessTokenWithAudience(audience, scopesToCollection(scopes));
+    }
+    /**
+     * Henter access token fra Maskinporten.
+     *
+     * @param request Request for access token
+     * @return Access token hentet fra Maskinporten
+     */
+    public String getAccessToken(@NonNull AccessTokenRequest request) {
         return getTokenForRequest(request);
     }
 

--- a/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/MaskinportenklientTest.java
+++ b/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/MaskinportenklientTest.java
@@ -150,7 +150,7 @@ class MaskinportenklientTest {
                             )
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getAccessToken(SCOPE);
+            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build());
             assertThat(accessToken).isNotBlank();
         }
     }
@@ -172,9 +172,9 @@ class MaskinportenklientTest {
                             ),
                     Times.exactly(1)).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getAccessToken(SCOPE);
+            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build());
             assertThat(accessToken).isNotBlank();
-            assertThat(maskinportenklient.getAccessToken(SCOPE)).isEqualTo(accessToken);
+            assertThat(maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build())).isEqualTo(accessToken);
         }
     }
 
@@ -197,7 +197,7 @@ class MaskinportenklientTest {
                             .withBody("FAILURE WAS AN OPTION AFTER ALL")
                             .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code()));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final MaskinportenTokenRequestException exception = catchThrowableOfType(() -> maskinportenklient.getAccessToken(SCOPE), MaskinportenTokenRequestException.class);
+            final MaskinportenTokenRequestException exception = catchThrowableOfType(() -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build()), MaskinportenTokenRequestException.class);
             assertThat(exception.getStatusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code());
         }
     }
@@ -211,7 +211,7 @@ class MaskinportenklientTest {
             localport = s.getLocalPort();
         }
         final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", localport));
-        final RuntimeException runtimeException = catchThrowableOfType(() -> maskinportenklient.getAccessToken(SCOPE), RuntimeException.class);
+        final RuntimeException runtimeException = catchThrowableOfType(() -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build()), RuntimeException.class);
         assertThat(runtimeException.getCause()).isInstanceOf(HttpHostConnectException.class);
 
     }
@@ -234,7 +234,9 @@ class MaskinportenklientTest {
             ).respond(response().withStatusCode(HttpStatusCode.FORBIDDEN_403.code())
                     .withBody(maskinportenError));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            MaskinportenClientTokenRequestException thrown = catchThrowableOfType(() -> maskinportenklient.getDelegatedAccessToken(consumerOrg, SCOPE), MaskinportenClientTokenRequestException.class);
+            MaskinportenClientTokenRequestException thrown = catchThrowableOfType(
+                    () -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().consumerOrg(consumerOrg).scope(SCOPE).build()),
+                    MaskinportenClientTokenRequestException.class);
             assertThat(thrown.getMaskinportenError()).isEqualTo(maskinportenError);
             assertThat(thrown.getStatusCode()).isEqualTo(HttpStatusCode.FORBIDDEN_403.code());
         }
@@ -257,7 +259,7 @@ class MaskinportenklientTest {
                             )
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getDelegatedAccessToken(consumerOrg, SCOPE);
+            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().consumerOrg(consumerOrg).scope(SCOPE).build());
             assertThat(accessToken).isNotBlank();
         }
     }
@@ -280,7 +282,7 @@ class MaskinportenklientTest {
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
 
-            final String accessToken = maskinportenklient.getAccessTokenWithAudience(audience, SCOPE);
+            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().audience(audience).scope(SCOPE).build());
             assertThat(accessToken).isNotBlank();
             SignedJWT jwt = SignedJWT.parse(accessToken);
             assertThat(jwt.getJWTClaimsSet().getAudience()).isEqualTo(Collections.singletonList(audience));

--- a/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/MaskinportenklientTest.java
+++ b/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/MaskinportenklientTest.java
@@ -150,7 +150,7 @@ class MaskinportenklientTest {
                             )
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build());
+            final String accessToken = maskinportenklient.getAccessToken(SCOPE);
             assertThat(accessToken).isNotBlank();
         }
     }
@@ -172,9 +172,9 @@ class MaskinportenklientTest {
                             ),
                     Times.exactly(1)).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build());
+            final String accessToken = maskinportenklient.getAccessToken(SCOPE);
             assertThat(accessToken).isNotBlank();
-            assertThat(maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build())).isEqualTo(accessToken);
+            assertThat(maskinportenklient.getAccessToken(SCOPE)).isEqualTo(accessToken);
         }
     }
 
@@ -197,7 +197,7 @@ class MaskinportenklientTest {
                             .withBody("FAILURE WAS AN OPTION AFTER ALL")
                             .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code()));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final MaskinportenTokenRequestException exception = catchThrowableOfType(() -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build()), MaskinportenTokenRequestException.class);
+            final MaskinportenTokenRequestException exception = catchThrowableOfType(() -> maskinportenklient.getAccessToken(SCOPE), MaskinportenTokenRequestException.class);
             assertThat(exception.getStatusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code());
         }
     }
@@ -211,7 +211,7 @@ class MaskinportenklientTest {
             localport = s.getLocalPort();
         }
         final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", localport));
-        final RuntimeException runtimeException = catchThrowableOfType(() -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(SCOPE).build()), RuntimeException.class);
+        final RuntimeException runtimeException = catchThrowableOfType(() -> maskinportenklient.getAccessToken(SCOPE), RuntimeException.class);
         assertThat(runtimeException.getCause()).isInstanceOf(HttpHostConnectException.class);
 
     }
@@ -234,9 +234,7 @@ class MaskinportenklientTest {
             ).respond(response().withStatusCode(HttpStatusCode.FORBIDDEN_403.code())
                     .withBody(maskinportenError));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            MaskinportenClientTokenRequestException thrown = catchThrowableOfType(
-                    () -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().consumerOrg(consumerOrg).scope(SCOPE).build()),
-                    MaskinportenClientTokenRequestException.class);
+            MaskinportenClientTokenRequestException thrown = catchThrowableOfType(() -> maskinportenklient.getDelegatedAccessToken(consumerOrg, SCOPE), MaskinportenClientTokenRequestException.class);
             assertThat(thrown.getMaskinportenError()).isEqualTo(maskinportenError);
             assertThat(thrown.getStatusCode()).isEqualTo(HttpStatusCode.FORBIDDEN_403.code());
         }
@@ -259,7 +257,7 @@ class MaskinportenklientTest {
                             )
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
-            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().consumerOrg(consumerOrg).scope(SCOPE).build());
+            final String accessToken = maskinportenklient.getDelegatedAccessToken(consumerOrg, SCOPE);
             assertThat(accessToken).isNotBlank();
         }
     }
@@ -282,7 +280,7 @@ class MaskinportenklientTest {
             ).respond(callback().withCallbackClass(OidcMockExpectation.class));
             final Maskinportenklient maskinportenklient = createClient(String.format("http://localhost:%s/token", client.getLocalPort()));
 
-            final String accessToken = maskinportenklient.getAccessToken(AccessTokenRequest.builder().audience(audience).scope(SCOPE).build());
+            final String accessToken = maskinportenklient.getAccessTokenWithAudience(audience, SCOPE);
             assertThat(accessToken).isNotBlank();
             SignedJWT jwt = SignedJWT.parse(accessToken);
             assertThat(jwt.getJWTClaimsSet().getAudience()).isEqualTo(Collections.singletonList(audience));


### PR DESCRIPTION
Endret klient til å ha kun en metode for henting av access token som tar et objekt med all nødvendig informasjon, som tillater flere permutasjoner av de forskjellige verdiene man kan sette på en request.