### PR TITLE
PID as an optional request claim, facilitating the use of end-user-restricted tokens

### DIFF
--- a/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/AccessTokenRequest.kt
+++ b/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/AccessTokenRequest.kt
@@ -16,7 +16,12 @@ data class AccessTokenRequest(
     /**
      * Ønsket audience for access token. Valgfritt.
      */
-    val audience: String? = null) {
+    val audience: String? = null,
+
+    /**
+     * PID ved ønske om end-user-restricted token. Valgfritt.
+     */
+    val pid: String? = null) {
 
     companion object {
         /**
@@ -37,6 +42,8 @@ class AccessTokenRequestBuilder {
     private var consumerOrg: String? = null
 
     private var audience: String? = null
+
+    private var pid: String? = null
 
     /**
      * Legger til et scope som skal brukes i forespørsel mot Maskinporten. Minst et scope må oppgies
@@ -71,12 +78,21 @@ class AccessTokenRequestBuilder {
     }
 
     /**
+     * Brukes til forespørsler der man ønsker at det resulterende tokenet skal være begenset til én sluttbruker.
+     */
+    fun pid(pid: String): AccessTokenRequestBuilder {
+        this.pid = pid
+        return this
+    }
+
+    /**
      * Bygger forespørselsobjekt
      */
     fun build(): AccessTokenRequest = AccessTokenRequest(
         scopes = scopes.toSet(),
         audience = this.audience,
-        consumerOrg = this.consumerOrg
+        consumerOrg = this.consumerOrg,
+        pid = this.pid
     )
 
 }

--- a/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
+++ b/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
@@ -163,6 +163,7 @@ class Maskinportenklient(privateKey: PrivateKey, certificate: X509Certificate, p
             .expirationTime(Date(expirationTimeInMillis))
         consumerOrg?.run { claimBuilder.claim(CLAIM_CONSUMER_ORG, this) }
         accessTokenRequest.audience?.run { claimBuilder.claim(CLAIM_RESOURCE, this) }
+        accessTokenRequest.pid?.run { claimBuilder.claim(CLAIM_PID, this) }
         val signedJWT = SignedJWT(
             jwsHeader, claimBuilder
                 .build()
@@ -274,6 +275,7 @@ class Maskinportenklient(privateKey: PrivateKey, certificate: X509Certificate, p
         const val CLAIM_SCOPE = "scope"
         const val CLAIM_CONSUMER_ORG = "consumer_org"
         const val CLAIM_RESOURCE = "resource"
+        const val CLAIM_PID = "pid"
         const val MDC_JTIID = "jtiId"
     }
 }

--- a/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/AccessTokenRequestBuilderTest.java
+++ b/maskinporten-client/src/test/java/no/ks/fiks/maskinporten/AccessTokenRequestBuilderTest.java
@@ -18,15 +18,18 @@ public class AccessTokenRequestBuilderTest {
         final String scopeTwo = "second";
         final String audience = "audience";
         final String consumerOrg = "999999999";
+        final String pid = "16032826532";
         final AccessTokenRequest accessTokenRequest = AccessTokenRequest.builder()
                 .scope(scopeOne)
                 .scope(scopeTwo)
                 .audience(audience)
                 .consumerOrg(consumerOrg)
+                .pid(pid)
                 .build();
         assertThat(accessTokenRequest.getScopes()).containsExactly(scopeOne, scopeTwo);
         assertThat(accessTokenRequest.getAudience()).isEqualTo(audience);
         assertThat(accessTokenRequest.getConsumerOrg()).isEqualTo(consumerOrg);
+        assertThat(accessTokenRequest.getPid()).isEqualTo(pid);
     }
 
     @DisplayName("Tester at builder fungerer som forventet også når vi oppgir scopes som Set")
@@ -37,14 +40,17 @@ public class AccessTokenRequestBuilderTest {
         final String scopeTwo = "second";
         final String audience = "audience";
         final String consumerOrg = "999999999";
+        final String pid = "16032826532";
         final AccessTokenRequest accessTokenRequest = AccessTokenRequest.builder()
                 .scopes(new HashSet(Arrays.asList(scopeOne, scopeTwo)))
                 .audience(audience)
                 .consumerOrg(consumerOrg)
+                .pid(pid)
                 .build();
         assertThat(accessTokenRequest.getScopes()).containsExactly(scopeOne, scopeTwo);
         assertThat(accessTokenRequest.getAudience()).isEqualTo(audience);
         assertThat(accessTokenRequest.getConsumerOrg()).isEqualTo(consumerOrg);
+        assertThat(accessTokenRequest.getPid()).isEqualTo(pid);
     }
 
 }


### PR DESCRIPTION
See e.g. https://docs.digdir.no/docs/Maskinporten/maskinporten_func_pid_restricted_tokens for description of usage

Maskinporten includes the provided PID in the resulting Maskinporten Token as a claim. Thereafter, when the token is used as authorization towards some other API, this claim must be validated against any PID provided in the request entity. If the PIDs do not match, the request should be rejected, as the authorization is not valid for the specified user.