### PR TITLE
Øker antall max connections fra 5 til 10 per route

### DIFF
--- a/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
+++ b/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
@@ -260,7 +260,7 @@ class Maskinportenklient(
         PoolingHttpClientConnectionManagerBuilder.create().setMaxConnPerRoute(10).build()
 
     private fun logConnectionManager(timeUsed: Long, connectionManager: PoolingHttpClientConnectionManager?) {
-        if (timeUsed > 10000 && connectionManager != null) {
+        if (timeUsed > 1000 && connectionManager != null) {
             log.debug {
                 """Connection pool has ${connectionManager.totalStats.available} available connections of ${connectionManager.totalStats.max} connections.
                     The maximum connections per route are ${connectionManager.defaultMaxPerRoute}. 

--- a/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
+++ b/maskinporten-client/src/main/kotlin/no/ks/fiks/maskinporten/Maskinportenklient.kt
@@ -15,6 +15,7 @@ import no.ks.fiks.maskinporten.error.MaskinportenTokenRequestException
 import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.core5.http.*
 import org.apache.hc.core5.http.io.HttpClientResponseHandler
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder
@@ -248,6 +249,7 @@ class Maskinportenklient(
             .disableRedirectHandling()
             .disableAuthCaching()
             .setDefaultRequestConfig(RequestConfig.custom().setConnectionRequestTimeout(properties.timeoutMillis.toLong(), TimeUnit.MILLISECONDS).build())
+            .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create().setMaxConnPerRoute(10).build())
             .build().use {
                 httpRequestResponse(it)
             }


### PR DESCRIPTION
En sjelden gang så bruker Maskinporten rundt 15 sekunder å hente token. En teori er at connection poolen er full, så prøver å doble denne for å se om dette har noe effekt. Default max antall connections totalt i poolen er 25, default max antall connections per route er 5. Men siden vi i Maskinporten alltid går mot samme route, så er det `setMaxConnPerRoute` som gir mening å endre.

Logger også informasjon om connection poolen hvis det tar lenger enn 10 sekunder å hente token. Dette forutsetter så klart at man bruker Maskinportenklienten sin http klient, og ikke har opprettet den selv.