### PR TITLE
Bumpet deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ks.fiks.pom</groupId>
         <artifactId>fiks-ekstern-kotlin-superpom</artifactId>
-        <version>1.2.7</version>
+        <version>1.2.8</version>
     </parent>
 
     <groupId>no.ks.fiks</groupId>
@@ -39,22 +39,22 @@
 
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 
-        <nimbus-jose-jwt.version>9.47</nimbus-jose-jwt.version>
-        <virksomhetssertifikat.version>4.0.1</virksomhetssertifikat.version>
+        <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
+        <virksomhetssertifikat.version>4.0.2</virksomhetssertifikat.version>
         <expiringmap.version>0.5.11</expiringmap.version>
         <mockserver.version>5.15.0</mockserver.version>
         <lang-tag.version>1.7</lang-tag.version>
-        <oauth2-oidc-sdk.version>11.20.1</oauth2-oidc-sdk.version>
+        <oauth2-oidc-sdk.version>11.21.2</oauth2-oidc-sdk.version>
         <apache-httpclient.version>5.4.1</apache-httpclient.version>
-        <apache-httpcore.version>5.3.1</apache-httpcore.version>
-        <bouncycastle.version>1.79</bouncycastle.version>
+        <apache-httpcore.version>5.3.2</apache-httpcore.version>
+        <bouncycastle.version>1.80</bouncycastle.version>
 
-        <junit.version>5.11.3</junit.version>
-        <assertj.version>3.26.3</assertj.version>
-        <mockk.version>1.13.13</mockk.version>
-        <mockito.version>5.14.2</mockito.version>
-        <micrometer.version>1.14.2</micrometer.version>
-        <dropwizard-metrics.version>4.2.29</dropwizard-metrics.version>
+        <junit.version>5.11.4</junit.version>
+        <assertj.version>3.27.3</assertj.version>
+        <mockk.version>1.13.16</mockk.version>
+        <mockito.version>5.15.2</mockito.version>
+        <micrometer.version>1.14.3</micrometer.version>
+        <dropwizard-metrics.version>4.2.30</dropwizard-metrics.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Dette er gjort:**

- Bumps [org.junit:junit-bom](https://github.com/junit-team/junit5) from 5.11.3 to 5.11.4.
- Bumps [no.ks.fiks.pom:fiks-ekstern-kotlin-superpom](https://github.com/ks-no/fiks-ekstern-super-pom) from 1.2.7 to 1.2.8.
- Bumps [no.ks.fiks:virksomhetssertifikat](https://github.com/ks-no/fiks-virksomhetssertifikat) from 4.0.1 to 4.0.2.
- Bumps [org.mockito:mockito-core](https://github.com/mockito/mockito) from 5.14.2 to 5.15.2.
- Bumps [com.nimbusds:nimbus-jose-jwt](https://bitbucket.org/connect2id/nimbus-jose-jwt) from 9.47 to 10.0.1.
- Bumps apache-httpcore.version from 5.3.1 to 5.3.2.
- Bumps [io.mockk:mockk-jvm](https://github.com/mockk/mockk) from 1.13.13 to 1.13.16.
- Bumps [io.micrometer:micrometer-core](https://github.com/micrometer-metrics/micrometer) from 1.14.2 to 1.14.3.
- Bumps [io.dropwizard.metrics:metrics-httpclient5](https://github.com/dropwizard/metrics) from 4.2.29 to 4.2.30.
- Bumps [org.bouncycastle:bcprov-jdk18on](https://github.com/bcgit/bc-java) from 1.79 to 1.80.
- Bumps [org.assertj:assertj-core](https://github.com/assertj/assertj) from 3.26.3 to 3.27.3.
- Bumps [com.nimbusds:oauth2-oidc-sdk](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions) from 11.20.1 to 11.21.2.